### PR TITLE
added set(CMAKE_CXX_STANDARD 17) flag in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@ cmake_minimum_required(VERSION 3.14.4)
 
 # Project
 project(protobuf-examples)
+set(CMAKE_CXX_STANDARD 17)
 
 # https://stackoverflow.com/questions/6594796/how-do-i-make-cmake-output-into-a-bin-dir
 # set(CMAKE_ARCHIVE_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/lib) # Not useful in this example


### PR DESCRIPTION
Hi, 

The compilation with `make` failed if we don't specify `CMAKE_CXX_STANDARD` in root CMakeLists.txt. The issue gets resolved if we add `set(CMAKE_CXX_STANDARD 17)` in root CMakeLists.txt. 

Rerefers to this [commit](https://github.com/Marslanali/Protocol_Buffer_Examples/commit/245e7ea58754e48fdc340ec553bd516edda08466) and now after `make` in build directory the binary files are generated successfully. 


```bash
mkdir build && cd build
cmake .. && make
```

### Terminal log after make
```bash
[ 14%] Running cpp protocol buffer compiler on /home/arslan/arslan/github/Protocol_Buffer_Examples/protos/addressbook.proto
Scanning dependencies of target addressbook
[ 28%] Building CXX object protos/CMakeFiles/addressbook.dir/addressbook.pb.cc.o
[ 42%] Linking CXX static library libaddressbook.a
[ 42%] Built target addressbook
Scanning dependencies of target add_people
[ 57%] Building CXX object examples/add_people/CMakeFiles/add_people.dir/add_people.cc.o
[ 71%] Linking CXX executable ../../bin/add_people
[ 71%] Built target add_people
Scanning dependencies of target list_people
[ 85%] Building CXX object examples/list_people/CMakeFiles/list_people.dir/list_people.cc.o
[100%] Linking CXX executable ../../bin/list_people
[100%] Built target list_people
```

Tested with Ubuntu 16.04 LTS running on x86/64 with `CMake version 3.17.5`.

Thanks,
Arslan 